### PR TITLE
Convert syntax to PHP 5.3

### DIFF
--- a/features/images/views/images.php
+++ b/features/images/views/images.php
@@ -4,7 +4,7 @@ $images = Images::get_images_for_event($id);
 if ($images['status'] == Images::OK) {
     $images = $images['values'];
 } else {
-    $images = [];
+    $images = array();
 }
 ?>
 <div class="row-fluid">

--- a/features/irc/views/irc.php
+++ b/features/irc/views/irc.php
@@ -4,7 +4,7 @@
  if ($channels['status'] == Irc::OK) {
      $channels = $channels['values'];
  } else {
-     $channels = [];
+     $channels = array();
  }
  $irc_config = Configuration::get_configuration("irc");
  $irc_channels = $irc_config["channels"];

--- a/features/jira/views/jira.php
+++ b/features/jira/views/jira.php
@@ -4,7 +4,7 @@
     if ($ticket_ids['status'] == Jira::OK) {
         $ticket_ids = $ticket_ids['values'];
     } else {
-        $ticket_ids = [];
+        $ticket_ids = array();
     }
     $jira_client = new JiraClient($curl_client);
     $jira_tickets = Jira::merge_jira_tickets($ticket_ids);

--- a/features/links/views/links.php
+++ b/features/links/views/links.php
@@ -4,7 +4,7 @@ $forum_links = Links::get_forum_links_for_event($id);
 if ($forum_links["status"] == Links::OK) {
     $forum_links = $forum_links["values"];
 } else {
-    $forum_links = [];
+    $forum_links = array();
 }
 
 ?>

--- a/phplib/Persistence.php
+++ b/phplib/Persistence.php
@@ -253,7 +253,7 @@ class Persistence {
                         ' VALUES (:postmortem_id,:value)';
                     $stmt = $conn->prepare($insert_sql);
                     $stmt->execute(array('postmortem_id' => $postmortem_id, 'value' => $value));
-                } elseif ($row_exists && self::get_postmortem($postmortem_id)['deleted'] == '1') {
+                } elseif ($row_exists && $postmortem = self::get_postmortem($postmortem_id) && $postmortem['deleted'] == '1') {
                     $update_sql = 'UPDATE ' . $table_name . ' SET deleted=1 WHERE id=:row_id';
                     $stmt = $conn->prepare($update_sql);
                     $stmt->execute(array('row_id' => $row_exists['id'], 'value' => $value));

--- a/phplib/Postmortem.php
+++ b/phplib/Postmortem.php
@@ -45,7 +45,8 @@ class Postmortem {
         }
         // store history
         $app = Slim::getInstance();
-        $admin = $app->environment()['admin']['username'];
+        $env = $app->environment();
+        $admin = $env['admin']['username'];
         self::add_history($event["id"], $admin, $action);
 
         // close connection and return

--- a/views/content/edit.php
+++ b/views/content/edit.php
@@ -134,7 +134,7 @@ foreach ($config['feature'] as $feature) {
   <?php if ($event['deleted']): ?>
     <legend>Restore</legend>
     <div id="undelete_button_container">
-    <a class="btn btn-danger" href="/events/<?= $event['id'] ?>/undelete">Undelete this Postmortem</a>
+    <a class="btn btn-danger" href="/events/<?php echo $event['id'] ?>/undelete">Undelete this Postmortem</a>
     </div>
   <?php else: ?>
     <legend>Delete</legend>

--- a/views/page.php
+++ b/views/page.php
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/assets/css/image_sizing.css" />
     <link rel="stylesheet" href="/assets/css/morgue.css" />
 
-    <title><?= isset($page_title) ? htmlentities($page_title) : 'Morgue' ?></title>
+    <title><?php echo isset($page_title) ? htmlentities($page_title) : 'Morgue' ?></title>
 
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>


### PR DESCRIPTION
Continuation of 844fdaeb628a749f30e58ff5cc4fcdee4d2f97c9
- Change `[]` to `array()`
- Replace short tags with `<?php echo`
- Remove function array dereferencing
