### PR TITLE
Remove WHERE clause when selecting all tags

### DIFF
--- a/phplib/Persistence.php
+++ b/phplib/Persistence.php
@@ -175,7 +175,7 @@ class Persistence {
                             WHERE postmortem_id=:postmortem_id
                                 AND pmt.deleted=:deleted';
             } else {
-                $get_sql = 'SELECT id, title FROM tags WHERE deleted = :deleted';
+                $get_sql = 'SELECT id, title FROM tags';
             }
         } elseif ($table_name == 'tags') {
             if (!isset($where['tag_ids'])) {


### PR DESCRIPTION
The `tags` table doesn't have a `deleted` column ([schema](https://github.com/etsy/morgue/blob/master/schemas/morgue.sql#L26)).

As mentioned in #8, when trying to fetch all of the tags a sql exception is thrown:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'deleted' in 'where clause'
```

Instead of removing the WHERE clause entirely I could change this to a `JOIN` with the [`postmortem_referenced_tags`](https://github.com/etsy/morgue/blob/master/schemas/morgue.sql#L32) table to only show tags that are being used. Let me know and I can update the PR.
