### PR TITLE
Make the JIRA fields to display configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ MORGUE_ENVIRONMENT=development php -d include_path=".:./features" -S localhost:8
 
 Open http://localhost:8000 to view Morgue
 
+## Configuration
+
+### JIRA feature
+
+**baseurl** the base URL to your jira installation (**use https** if you are using a secured JIRA installation)  
+**username** username for a user with viewing credentials  
+**password** password for a user with viewing credentials  
+**additional_fields** mapping of fields to display in morgue (other than key, summay, assignee, status)  
+
+```
+    {   "name": "jira",
+        "enabled": "on",
+        "baseurl": "https://jira.foo.com",
+        "username": "jira_morgue",
+        "password": "jira_morgue",
+        "additional_fields" : {
+            "Due Date" : "duedate",
+            "Some Custom Field" : "customfield_1234"
+        }
+    },
+```
+
 ## Tests
 You can run the unit test suite with:
 ```

--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -530,7 +530,8 @@ function confirm_delete(message, insert, context, onConfirm, onDisappear) {
   alert.hide().insertAfter(insert);
   alert.fadeIn(200);
 
-  alert.on("click", "#alert_yes_button", function() {
+  alert.on("click", "#alert_yes_button", function(ev) {
+    ev.preventDefault();
     onConfirm.call(context);
     alert.fadeOut(200, function() {
       alert.remove();
@@ -538,7 +539,8 @@ function confirm_delete(message, insert, context, onConfirm, onDisappear) {
     });
   });
 
-  alert.on("click", "#alert_no_button", function() {
+  alert.on("click", "#alert_no_button", function(ev) {
+    ev.preventDefault();
     alert.fadeOut(200, function() {
       alert.remove();
       onDisappear.call(context);

--- a/assets/js/jira.js
+++ b/assets/js/jira.js
@@ -14,7 +14,10 @@ function addTicket() {
                     entry += "<td><a href=\""+data[i].ticket_url+"\" class=\""+ style + "\">"+i+"</a></td>";
                     entry += "<td>"+data[i].summary+"</td>";
                     entry += "<td>"+data[i].assignee+"</td>";
-                    entry += "<td>"+(data[i].due_date || "" )+"</td>";
+                    $('th.jira_addition_field').each(function(index, value){
+                        field = $(value).text();
+                        entry += "<td>"+(data[i][field] || "" )+"</td>";
+                    });
                     entry += "<td><span id=\"jira-"+data[i].id+"\" class='close'>&times;</span></td>";
                     entry += "</tr>";
                 

--- a/config/development.json
+++ b/config/development.json
@@ -40,7 +40,9 @@
         "enabled": "on",
         "baseurl": "https://jira.foo.com",
         "username": "jira_morgue",
-        "password": "jira_morgue_password"
+        "password": "jira_morgue_password",
+        "additional_fields" : {
+        }
     },
 
     {   "name": "links",

--- a/features/jira/views/jira.php
+++ b/features/jira/views/jira.php
@@ -21,7 +21,11 @@
         <th>Key</th>
         <th>Summary</th>
         <th>Assignee</th>
-        <th>Due Date</th>
+        <?php
+        foreach ($jira_client->getAdditionalIssueFields() as $k => $v) {
+            echo "<th class='jira_addition_field'>$k</th>";
+        }
+        ?>
         <th></th>
       </tr>
     </thead>
@@ -33,7 +37,9 @@
         echo "<td><a href=$ticket_attributes[ticket_url] class=\"$style\">$ticket_key</a></td>";
         echo "<td>$ticket_attributes[summary]</td>";
         echo "<td>$ticket_attributes[assignee]</td>";
-        echo "<td>$ticket_attributes[due_date]</td>";
+        foreach ($jira_client->getAdditionalIssueFields() as $k => $v) {
+            echo "<td>$ticket_attributes[$k]</td>";
+        }
         echo "<td><span id=\"jira-$ticket_attributes[id]\" class='close'>&times;</span></td>";
         echo "</tr>";
       }

--- a/tests/unit/JiraClient_Test.php
+++ b/tests/unit/JiraClient_Test.php
@@ -5,6 +5,21 @@ require_once(__DIR__."/../../phplib/CurlClient.php");
 require_once(__DIR__."/../../phplib/Configuration.php");
 
 class JiraClientTest extends PHPUnit_Framework_TestCase {
+    const JIRA_BASE_URL = "https://jira.foo.com";
+    const JIRA_USERNAME = 'jira';
+    const JIRA_PASSWORD = 'credentials';
+
+    public function setUp() {
+        // create a mock curl client
+        $this->curl_client = $this->getMock('CurlClient', array('get'));
+        $this->jira_client = new JiraClient(
+            $this->curl_client, array(
+                "baseurl" => self::JIRA_BASE_URL,
+                "username" => self::JIRA_USERNAME,
+                "password" => self::JIRA_PASSWORD
+            )
+        );
+    }
 
     public function testObjectCreation() {
         $curl_client = new CurlClient();
@@ -12,20 +27,71 @@ class JiraClientTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('JiraClient', get_class($jira));
     }
 
-    public function test_getJiraApiResponses() {
-        // create a mock curl client
-        $curl = $this->getMock('CurlClient', array('get'));
-        // set up expectations and return value
-        $curl->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('https://jira.foo.com/rest/api/2/issue/MAYHEM-1148'))
-            ->will($this->returnValue(file_get_contents(__DIR__."/../fixtures/response1772.json")));
+    public function test_getJiraApiResponse_withTickets() {
 
-        $jira = new JiraClient($curl, array("baseurl" => "https://jira.foo.com", "username" => "foo", "password" => "bar"));
-        $jira_responses = $jira->getJiraApiResponse(array('MAYHEM-1148'));
-        $this->assertTrue(is_array($jira_responses));
-        $this->assertEquals(1, count($jira_responses));
-        $this->assertEquals("MAYHEM-1148", $jira_responses[0]["key"]);
-        $this->assertEquals("bmacri", $jira_responses[0]['fields']['assignee']['name']);
+        // set up expectations and return value
+        $expected_url = self::JIRA_BASE_URL . '/rest/api/2/search';
+
+        $expected_params = array(
+            'jql' => 'issuekey in ("FOO-123","BAR-456","BAZ-7")',
+            'maxResults' => 3,
+            'fields' => 'x,y,z'
+        );
+
+        $expected_creds = self::JIRA_USERNAME . ':' . self::JIRA_PASSWORD;
+
+        $this->curl_client
+             ->expects($this->once())
+             ->method('get')
+             ->with($this->equalTo($expected_url), $this->equalTo($expected_params), $this->equalTo($expected_creds))
+             ->will($this->returnValue('{"json": "response"}'));
+
+        $fields = array('x', 'y' ,'z');
+        $jira_response = $this->jira_client->getJiraApiResponse(array("FOO-123", "BAR-456", "BAZ-7"), $fields);
+        $this->assertEquals(array('json' => 'response'), $jira_response);
+    }
+
+    public function test_getJiraApiResponse_withoutTickets() {
+        // create a mock curl client
+        $this->curl_client->expects($this->never())
+            ->method('get');
+
+
+        $fields = array('x', 'y' ,'z');
+        $jira_response = $this->jira_client->getJiraApiResponse(array(), $fields);
+        $this->assertEquals(array(), $jira_response);
+    }
+
+
+    public function provideTicketsFieldsRequirements() {
+        return array(
+            array( array('Foo' => 'foo'), array('Foo' => 'X')), # simple field
+            array( array('BaZ' => 'baz'), array('BaZ' => 'Z')), # nested field
+            array( array('Bar' => 'bar'), array('Bar' => '')), # field not found
+            array( array('Foo' => 'foo', 'BaZ' => 'baz'), array('Foo' => 'X', 'BaZ' => 'Z')), # 2 fields
+        );
+    }
+
+    /**
+      * @dataProvider provideTicketsFieldsRequirements
+      */
+    public function test_unpackTicketInfo($fields, $expected) {
+        $ticket_info = array(
+            'key' => 'ABC',
+            'fields' => array(
+                'foo' => 'X',
+                'bar' => array('qux'=>'Y'),
+                'baz' => array('name'=>'Z'),
+            )
+        );
+        $actual = $this->jira_client->unpackTicketInfo($ticket_info, $fields);
+        $expected['ticket_url'] = self::JIRA_BASE_URL . '/browse/ABC';
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_unpackTicketInfo_emptyissue() {
+        $ticket_info = array();
+        $actual = $this->jira_client->unpackTicketInfo($ticket_info, array('Foo' => 'foo'));
+        $this->assertEquals(array('Foo' => ''), $actual);
     }
 }


### PR DESCRIPTION
This change allows anyone to define a list of additional fields to display in Morgue - by default, the only reported fields are
- key
- summary
- status
- assignee
- link

Additionally, the querying mechansim has been changed to query all the issues related to a post mortem at once (using a JQL query), instead of querying issues one by one.
