### PR TITLE
Allow severity levels to be configured

### DIFF
--- a/assets/js/severity_tooltip.js
+++ b/assets/js/severity_tooltip.js
@@ -1,12 +1,12 @@
+var severity_levels = $.map($("#severity-select option"),function(val,i) {
+    return (i+1) + ". " + $(val).attr('description');
+});
+
 $("#event-severity").popover({
     trigger:"none",
     html: true,
-    title: "<a href='https://jira.etsycorp.com/confluence/display/auto/How+we+prioritize+bugs+at+Etsy' target='_new'>service tiers</a> and <a href='https://jira.etsycorp.com/confluence/display/SYS/Outage+Severity+Levels' target='_new'>severity levels</a>",
-    content: "1. Complete outage or degradation so severe that core functionality is unusable <br>"
-            +"2. Functional degradation for a subset of members or loss of some core functionality for all members <br>"
-            +"3. Noticeable degradation or loss of minor functionality <br>"
-            +"4. No member-visible impact; loss of redundancy or capacity <br> "
-            +"5. Anything worth mentioning not in the above levels"
+    title: $("#severity-select").attr("title"),
+    content: severity_levels.join('<br/>')
 });
 
 $("#event-severity").click(function(event) {

--- a/config/development.json
+++ b/config/development.json
@@ -9,6 +9,18 @@
         "password": "morgue_password"
     },
 
+
+    "severity" :
+    { "tooltip_title" : "Severity Levels",
+      "levels" : [
+            "Complete outage or degradation so severe that core functionality is unusable",
+            "Functional degradation for a subset of members or loss of some core functionality for all members",
+            "Noticeable degradation or loss of minor functionality",
+            "No member-visible impact; loss of redundancy or capacity",
+            "Anything worth mentioning not in the above levels"
+        ]
+    },
+
     "feature": [
 
     {   "name": "status_time",

--- a/config/production.json
+++ b/config/production.json
@@ -9,6 +9,17 @@
         "password": "morgue_password"
     },
 
+    "severity" :
+    { "tooltip_title" : "Severity Levels",
+      "levels" : [
+            "Complete outage or degradation so severe that core functionality is unusable",
+            "Functional degradation for a subset of members or loss of some core functionality for all members",
+            "Noticeable degradation or loss of minor functionality",
+            "No member-visible impact; loss of redundancy or capacity",
+            "Anything worth mentioning not in the above levels"
+        ]
+    },
+
     "feature": [
 
     {   "name": "status_time",

--- a/features/jira/lib.php
+++ b/features/jira/lib.php
@@ -234,7 +234,7 @@ class JiraClient {
      *
      * @param $jira_key_input -> same parameter given for getJiraApiResponse, $api_response -> defaults to null
      *
-     * @return $jira_tickets an array where key is an jira ticket key (i.e. 'CORE-1204') and val is an array of jira ticket attributes, such as 'ticket_url' => 'https://jira.etsycorp.com/CORE-1204'
+     * @return $jira_tickets an array where key is an jira ticket key (i.e. 'CORE-1204') and val is an array of jira ticket attributes, such as 'ticket_url' => 'https://jira.foo.com/CORE-1204'
      */
 
     function getJiraTickets($jira_key_input, $api_response = null) {

--- a/phplib/Postmortem.php
+++ b/phplib/Postmortem.php
@@ -513,4 +513,17 @@ class Postmortem {
         }
     }
 
+    /**
+      * Provide the different severity levels for a post mortem event
+      *
+      * @returns array of severity levels
+      */
+    static function get_severity_levels() {
+        $config = Configuration::get_configuration();
+        if (isset($config['severity']) && isset($config['severity']['levels'])) {
+            return $config['severity']['levels'];
+        } else {
+            return array('default');
+        }
+    }
 }

--- a/views/content/edit.php
+++ b/views/content/edit.php
@@ -72,13 +72,28 @@ Filler, to keep the same size
    <div class="control-group">
      <label class="control-label severity_levels" id="event-severity">Severity: </label>
        <div class="controls controls-row">
-        <select id="severity-select" name="severity" class="input-small">
-        <?php foreach (range(0, 5) as $a_severity) : ?>
-          <option value="<?php echo $a_severity ?>"
-            <?php if ($a_severity == $severity) { echo "selected=\"true\"";}?>>
-            <?php echo $a_severity ?>
-          </option>
-        <?php endforeach ?>
+        <select id="severity-select" name="severity" class="input-small" title="
+        <?php
+           $config = Configuration::get_configuration();
+           if (isset($config['severity']) && isset($config['severity']['tooltip_title'])) {
+               echo $config['severity']['tooltip_title'];
+            } else {
+                echo "Severity Levels";
+            }
+        ?>
+        ">
+
+        <?php
+        $severity_levels = Postmortem::get_severity_levels();
+        foreach ($severity_levels as $level => $desc) {
+            $sev_level = $level + 1;
+            echo '<option value="' . $sev_level . '" description="' . $desc . '"';
+            if ($sev_level == $severity) {
+                echo 'selected="true"';
+            }
+            echo '>' . $sev_level . '</option>';
+        }
+        ?>
         </select>
       </div>
     </div>

--- a/views/modal/create.php
+++ b/views/modal/create.php
@@ -58,13 +58,12 @@
       <label id="severity_levels" class="control-label severity_levels" for="severity">Severity</label><p>
       <div class="controls">
           <select id="severity" name="severity" class="input-small">
-            <option>1</option>
-            <option>2</option>
-            <option>3</option>
-            <option>4</option>
-            <option>5</option>
+          <?php
+          $severity_levels = Postmortem::get_severity_levels();
+          foreach (range(1, count($severity_levels)) as $a_severity) {
+            echo '<option>' . $a_severity . '</option>';
+          } ?>
           </select>
-      </select>
       </div>
       </div>
 


### PR DESCRIPTION
Severity levels and tooltip title can now be configured in the config file. This mechanism is fairly weak and does not escape the configuration items - escaped strings in the config will break the html in the template - use single quotes instead.
