### PR TITLE
Make timezone as a global app setting

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -365,7 +365,7 @@ function update_detectdate_for_event() {
         url: url, 
         data: {
                detect_date: $("input#event-detect-input-date").val(),
-               timezone: 'America/New_York'
+               timezone: $('#current_tz').text()
                }, 
         type: "PUT",
         success: function () { show_save_status("Detect date", true);},
@@ -380,7 +380,7 @@ function update_detecttime_for_event() {
         url: url, 
         data: {
                detect_time: $("input#event-detect-input-time").val(),
-               timezone: 'America/New_York'
+               timezone: $('#current_tz').text()
                }, 
         type: "PUT",
         success: function () { show_save_status("Detect time", true);},
@@ -396,7 +396,7 @@ function update_statusdatetime_for_event() {
         url: url, 
         data: {
                status_datetime: $("input#event-status-input-date").val() + ' ' + $("input#event-status-input-time").val(),
-               timezone: 'America/New_York'
+               timezone: $('#current_tz').text()
                }, 
         type: "PUT",
         success: function () { show_save_status("Status time", true);},
@@ -410,7 +410,7 @@ function update_enddate_for_event() {
         url: url, 
         data: {
                end_date: $("input#event-end-input-date").val(),
-               timezone: 'America/New_York'
+               timezone: $('#current_tz').text()
                }, 
         type: "PUT",
         success: function () { show_save_status("End date", true);},
@@ -425,7 +425,7 @@ function update_endtime_for_event() {
         url: url, 
         data: {
                end_time: $("input#event-end-input-time").val(),
-               timezone: 'America/New_York'
+               timezone: $('#current_tz').text()
                }, 
         type: "PUT",
         success: function () { show_save_status("End time", true);},
@@ -441,7 +441,7 @@ function update_startdate_for_event() {
         url: url, 
         data: {
                start_date: $("input#event-start-input-date").val(),
-               timezone: 'America/New_York'
+               timezone: $('#current_tz').text()
                }, 
         type: "PUT",
         success: function () { show_save_status("Start date", true);},
@@ -456,7 +456,7 @@ function update_starttime_for_event() {
         url: url, 
         data: {
                start_time: $("input#event-start-input-time").val(),
-               timezone: 'America/New_York'
+               timezone: $('#current_tz').text()
                }, 
         type: "PUT",
         success: function () { show_save_status("Start time", true);},

--- a/assets/js/irc.js
+++ b/assets/js/irc.js
@@ -72,7 +72,7 @@ $('#ircchannels').on('click', 'a.ircshow', function() {
     end_date: enddate,
     end_time: endtime,
     channel: channel.replace("#",""),
-    timezone: "America/New_York",
+    timezone: $('#current_tz').text(),
     offset: 0
   };
   $('#irc-modal-headline').html(topic);

--- a/config/example.json
+++ b/config/example.json
@@ -1,5 +1,6 @@
 {
     "environment": "development",
+    "timezone": "Europe/Zurich",
 
     "database":
     {  "mysqlhost": "localhost",

--- a/index.php
+++ b/index.php
@@ -17,11 +17,21 @@ $app = new Slim();
 // must be require_once'd after the Slim autoloader is registered
 require_once __DIR__.'/phplib/AssetVersionMiddleware.php';
 
-// helper method for returning the users current timezone
-// if set, otherwise defaulting to 'America/New_York'
+// helper method for returning the selected timezone.
+// If set, get the user timezone else get it from the global config
+// otherwise default to 'America/New_York'
 // returns: string
 function getUserTimezone() {
-    return isset($_SESSION['timezone']) ? $_SESSION['timezone'] : 'America/New_York';
+    $config = Configuration::get_configuration();
+    $tz = 'America/New_York';
+
+    if ( isset($_SESSION['timezone']) ) {
+      $tz = $_SESSION['timezone'];
+    } else if ( isset($config['timezone']) ) {
+      $tz = $config['timezone'];
+    }
+
+    return $tz;
 }
 
 // helper method to sort events reverse by starttime

--- a/views/content/frontpage.php
+++ b/views/content/frontpage.php
@@ -10,8 +10,8 @@
           </tr>
         </thead>
       <?php
-      $timezone = isset($_SESSION['timezone']) ? $_SESSION['timezone'] : 'America/New_York';
-      $tz = new DateTimeZone($timezone);
+
+      $tz = new DateTimeZone( getUserTimezone() );
       foreach ($events as $event) {
         $start = new DateTime("@".$event["starttime"]);
         $start->setTimezone($tz);

--- a/views/timezone.php
+++ b/views/timezone.php
@@ -2,5 +2,5 @@
   <a class="btn btn-large btn-block btn-primary" data-toggle="modal" href="#tz" data-target="#tz">
     <i class="icon-globe icon-white"></i> Change Timezone
   </a>
-  <div style="text-align: center"><b>Current:</b> <?php echo getUserTimezone() ?></div>
+  <div style="text-align: center"><b>Current:</b> <span id="current_tz"><?php echo getUserTimezone() ?></span></div>
 <?php include __DIR__.'/modal/timezone.php' ?>


### PR DESCRIPTION
Timezone should be part of the app settings. The selection still defaults to America/New_York if nothing set to keep existing installations in a good shape.
