### PR TITLE
Refactor the anniversary code; adds a view that mails out anniversary announcements

### DIFF
--- a/features/anniversary/lib.php
+++ b/features/anniversary/lib.php
@@ -30,4 +30,39 @@ class Anniversary extends Persistence {
                          "values" => array());
         }
     }
+static function render_tags($tags) {
+    $out = '';
+    foreach ($tags as $tag) {
+        $tag['title'] = ucfirst($tag['title']);
+        $out .= "<span class='label tag' id='tag-" .$tag['id'] . "'>{$tag['title']}</span>&nbsp;";
+    }
+    return $out;
+}
+
+static function render_outage($pm) {
+    if (empty($pm['title'])) {
+        $pm['title'] = "untitled";
+    }
+    $nice_start = date("r", $pm['starttime']);
+    $nice_end= date("r", $pm['endtime']);
+    $nice_tags = self::render_tags($pm['tags']);
+
+    if (!$nice_tags) {
+        $nice_tags = "This event has no tags";
+    }
+    $out = <<<HTML
+    <div>
+    <strong><a href="/events/{$pm['id']}">{$pm['title']}</a></strong><br />
+    {$nice_start} to {$nice_end}  <br />
+    Severity: {$pm['severity']} <br />
+
+    <div id='tag_well' class='well well-small'>$nice_tags</div>
+
+    </div>
+    <hr />
+HTML;
+    return $out;
+}
+
+
 }

--- a/features/anniversary/routes.php
+++ b/features/anniversary/routes.php
@@ -47,4 +47,75 @@ $app->get('/anniversary', function () use ($app) {
 
 });
 
+$app->get('/anniversary/mail', function () use ($app) {
+    $config =  Configuration::get_configuration('anniversary');
+    if ($config['enabled'] !== 'on') {
+        return;
+    }
+    if (empty($config['mailto'])) {
+        return;
+    }
 
+
+    $content = "anniversary/views/anniversary-mail";
+
+    $show_sidebar = false;
+    $page_title = "Today in Post Mortem History";
+    $today = date("Y-m-d", time());
+
+    $get_date = trim($app->request()->get('date'));
+    if ($get_date) {
+        $get_date = date("Y-m-d", strtotime($get_date));
+        $today = $get_date;
+    }
+
+    $conn = Persistence::get_database_object();
+    $pm_ids = Anniversary::get_ids($today, $conn);
+    $human_readable_date = date("F jS", strtotime($today));
+    $pms = array();
+
+    if ($pm_ids['status'] === 0) {
+        foreach ($pm_ids['values'] as $k => $v) {
+            $pm = Persistence::get_postmortem($v['id'], $conn);
+            $pms[] = $pm;
+        }
+    } else {
+        $message = $pm_ids['error'];
+        $content = "error";
+        include 'views/page.php';
+        return;
+    }
+
+    if (count($pms)) {
+        // get the tags for each PM we found so we can display them
+        foreach ($pms as $k => $pm) {
+            $tags = Postmortem::get_tags_for_event($pm['id'], null);
+            $pms[$k]['tags'] = $tags['values'];
+        }
+    }
+
+    if (count($pms)) {
+
+        ob_start();
+        include $content. ".php";
+        $out = ob_get_contents();
+        ob_end_clean();
+
+        print $out;
+
+        $to = $config['mailto'];
+        $subject = "$subject";
+        $message = $out;
+        $headers = "From: {$config['mailfrom']}\r\n";
+        $headers  = 'MIME-Version: 1.0' . "\r\n";
+        $headers .= 'Content-type: text/html; charset=utf-8' . "\r\n";
+        $headers .= "Return-Path: {$config['mailfrom']}\r\n";
+
+        $ok = mail($to, $subject, $message, $headers, "-f{$config['mailfrom']}");
+
+        print  "Mail sent. {$ok}";
+    } else {
+        print "Nothing broke on this date.";
+    }
+
+});

--- a/features/anniversary/views/anniversary-mail.php
+++ b/features/anniversary/views/anniversary-mail.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Version of the anniversay page suitble to email
+ */
+
+print <<<CSS
+    <base href="http://{$_SERVER['SERVER_NAME']}" />
+    <style>
+        .label.tag {
+            margin-right: 20px;
+            background-color: #999;
+            padding:5px;
+            color: white;
+        }
+        #tag_well {
+            margin-top:10px;
+        }
+    </style>
+CSS;
+
+$count = count($pms);
+if ($count) {
+    if ($count === 1) {
+        $outage = "an outage";
+    } else {
+        $outage =  $count . " outages";
+    }
+    $subject = "$human_readable_date is the anniversary of {$outage}.";
+    echo "<h3>${subject}</h3>";
+    foreach ($pms as $k => $v) {
+        print Anniversary::render_outage($v);
+    }
+}

--- a/features/anniversary/views/anniversary.php
+++ b/features/anniversary/views/anniversary.php
@@ -2,37 +2,6 @@
 /**
  * Today in Post Mortem History
  */
-function render_tags($tags) {
-    $out = '';
-    foreach ($tags as $tag) {
-        $out .= "<span class='label tag' id='tag-" .$tag['id'] . "'>{$tag['title']}</span>";
-    }
-    return $out;
-}
-function render_outage($pm) {
-    if (empty($pm['title'])) {
-        $pm['title'] = "untitled";
-    }
-    $nice_start = date("r", $pm['starttime']);
-    $nice_end= date("r", $pm['endtime']);
-    $nice_tags = render_tags($pm['tags']);
-
-    if (!$nice_tags) {
-        $nice_tags = "This event has no tags";
-    }
-    $out = <<<HTML
-    <div>
-    <strong><a href="/events/{$pm['id']}">{$pm['title']}</a></strong><br />
-    {$nice_start} to {$nice_end}  <br />
-    Severity: {$pm['severity']} <br />
-
-    <div id='tag_well' class='well well-small'>$nice_tags</div>
-
-    </div>
-    <hr />
-HTML;
-    return $out;
-}
 
 $count = count($pms);
 if ($count) {
@@ -43,7 +12,7 @@ if ($count) {
     }
     echo "<h3>$human_readable_date is the anniversary of {$outage}.</h3>";
     foreach ($pms as $k => $v) {
-        print render_outage($v);
+        print Anniversary::render_outage($v);
     }
 } else {
     echo "<p>Nothing broke on $human_readable_date.</p>";


### PR DESCRIPTION
To make use of this a few new keys need to be added to the anniversary feature config. These tell morgue where to email the announcement and what to set the From: headers to.

```
    { "name" : "anniversary",
      "enabled": "on",
      "navbar" : "on",
      "mailto" : "outage-announce@yourco.com",
      "mailfrom" : "Morgue <morge@yourco.com>"
    },
```
