### PR TITLE
Teach morgue how to load views from features outside its core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ is used to determine which config file to use (see above step).
     </VirtualHost>
 ```
 
+**NOTE**: If you maintain a custom Morgue features outside the document root, be
+sure to include that directory in the ``php_value include_path`` directive.
+
 Restart apache and hit the servername you defined above.
 
 ### MySQL

--- a/config/example.json
+++ b/config/example.json
@@ -33,8 +33,6 @@
       "tags",
       "history"
     ],
-    "custom_features": "on",
-    "custom_feature_path": "/usr/local/morgue_features",
     "feature": [
 
     {   "name": "status_time",

--- a/config/example.json
+++ b/config/example.json
@@ -33,6 +33,11 @@
       "tags",
       "history"
     ],
+    "custom_assets": {
+        "note": "This alias must match an Alias directive in the Apache vhost config.",
+        "alias": "/morgue_custom_features",
+        "path": "/usr/local/morgue_features"
+    },
     "feature": [
 
     {   "name": "status_time",

--- a/config/example.json
+++ b/config/example.json
@@ -31,13 +31,9 @@
       "jira",
       "links",
       "tags",
-      "history"
+      "history",
+      "custom_feature"
     ],
-    "custom_assets": {
-        "note": "This alias must match an Alias directive in the Apache vhost config.",
-        "alias": "/morgue_custom_features",
-        "path": "/usr/local/morgue_features"
-    },
     "feature": [
 
     {   "name": "status_time",
@@ -85,6 +81,11 @@
 
     {   "name": "history",
         "enabled": "on"
+    },
+
+    {   "name": "custom_feature",
+        "enabled": "on",
+        "custom_js_assets": "on"
     }
 
     ]

--- a/config/example.json
+++ b/config/example.json
@@ -33,7 +33,8 @@
       "tags",
       "history"
     ],
-
+    "custom_features": "on",
+    "custom_feature_path": "/usr/local/morgue_features",
     "feature": [
 
     {   "name": "status_time",

--- a/views/content/edit.php
+++ b/views/content/edit.php
@@ -133,16 +133,36 @@ Filler, to keep the same size
 
 <?php
         $config = Configuration::get_configuration();
+        // Set these in a more global scope. Methinks Configuration::get_configuration
+        // overwrites '$config' in places...
+        $custom_features = $config['custom_features'];
+        $custom_feature_path = $config['custom_feature_path'];
         $edit_page_features = $config['edit_page_features'];
 
         foreach ($edit_page_features as $feature_name) {
             $feature = Configuration::get_configuration($feature_name);
             if ($feature['enabled'] == "on") {
                 $view_file = $feature['name'] . '/views/' . $feature['name'] . '.php';
-                if (file_exists('features/' . $view_file)) {
-                    include $view_file;
+                // Check if we have custom features enabled and load the view.
+                if (isset($custom_features) && $custom_features == "on") {
+                    $custom_feature_view_file = $custom_feature_path . '/' . $view_file;
+                    if (file_exists($custom_feature_view_file)) {
+                        include $custom_feature_view_file;
+                    } else {
+                        // Try finding the feature in the core project.
+                        if (file_exists('features/' . $view_file)) {
+                            include $view_file;
+                        } else {
+                            error_log('No views found for ' . $feature['name'] . ' feature');
+                        }
+                    }
                 } else {
-                    error_log('No views found for ' . $feature['name'] . ' feature');
+                    // Look for the feature in the core project.
+                    if (file_exists('features/' . $view_file)) {
+                        include $view_file;
+                    } else {
+                        error_log('No views found for ' . $feature['name'] . ' feature');
+                    }
                 }
             }
         }

--- a/views/content/edit.php
+++ b/views/content/edit.php
@@ -133,36 +133,18 @@ Filler, to keep the same size
 
 <?php
         $config = Configuration::get_configuration();
-        // Set these in a more global scope. Methinks Configuration::get_configuration
-        // overwrites '$config' in places...
-        $custom_features = $config['custom_features'];
-        $custom_feature_path = $config['custom_feature_path'];
         $edit_page_features = $config['edit_page_features'];
 
         foreach ($edit_page_features as $feature_name) {
             $feature = Configuration::get_configuration($feature_name);
             if ($feature['enabled'] == "on") {
                 $view_file = $feature['name'] . '/views/' . $feature['name'] . '.php';
-                // Check if we have custom features enabled and load the view.
-                if (isset($custom_features) && $custom_features == "on") {
-                    $custom_feature_view_file = $custom_feature_path . '/' . $view_file;
-                    if (file_exists($custom_feature_view_file)) {
-                        include $custom_feature_view_file;
-                    } else {
-                        // Try finding the feature in the core project.
-                        if (file_exists('features/' . $view_file)) {
-                            include $view_file;
-                        } else {
-                            error_log('No views found for ' . $feature['name'] . ' feature');
-                        }
-                    }
+                // Walk the include path looking for our view file.
+                $view_path_exists = stream_resolve_include_path($view_file);
+                if ($view_path_exists) {
+                    include $view_file;
                 } else {
-                    // Look for the feature in the core project.
-                    if (file_exists('features/' . $view_file)) {
-                        include $view_file;
-                    } else {
-                        error_log('No views found for ' . $feature['name'] . ' feature');
-                    }
+                    error_log('No views found for ' . $feature['name'] . ' feature');
                 }
             }
         }

--- a/views/content/edit.php
+++ b/views/content/edit.php
@@ -194,21 +194,18 @@ Filler, to keep the same size
 <script type="text/javascript" src="/assets/js/forums.js"></script>
 <script type="text/javascript" src="/assets/js/edit.js"></script>
 <?php
-    // Enumerate any custom javascript and make them accessible externally.
-    // Requires that Morgue's config includes a custom asset alias and path
-    // that match a defined Alias directive in the Apache vhost config.
+    // Enumerate any custom javascript assets and make them accessible externally.
     $config = Configuration::get_configuration();
-    if (isset($config['custom_assets']['alias']) and isset($config['custom_assets']['path'])) {
-        $custom_asset_alias = $config['custom_assets']['alias'];
-        $custom_asset_path = $config['custom_assets']['path'];
-        // Find dem scripts...
-        $custom_js = glob("$custom_asset_path/assets/js/*.js");
-        if ($custom_js) {
-            foreach ($custom_js as $js) {
-                // Replace the system path with the alias.
-                $aliased_js = str_replace($custom_asset_path, $custom_asset_alias, $js);
-                echo "<script type=\"text/javascript\" src=\"$aliased_js\"></script>";
-            }
+    $edit_page_features = $config['edit_page_features'];
+    foreach ($edit_page_features as $feature_name) {
+        $feature = Configuration::get_configuration($feature_name);
+        if (isset($feature['custom_js_assets']) and $feature['custom_js_assets'] == "on") {
+            // Build up the path to the appropriate route for this asset.
+            // The feature's routes.php should include a route that locates and serves the static asset.
+            // The directory containing custom Morgue features should follow the same structure as the
+            //core project, including an 'assets/js/' directory. Doing this, the route declaration can
+            // call stream_resolve_include_path() to locate the asset via the include_path.
+            echo "<script type=\"text/javascript\" src=\"/$feature_name/assets/js/$feature_name.js\"></script>";
         }
     }
 ?>

--- a/views/content/edit.php
+++ b/views/content/edit.php
@@ -193,3 +193,22 @@ Filler, to keep the same size
 <script type="text/javascript" src="/assets/js/severity_tooltip.js"></script>
 <script type="text/javascript" src="/assets/js/forums.js"></script>
 <script type="text/javascript" src="/assets/js/edit.js"></script>
+<?php
+    // Enumerate any custom javascript and make them accessible externally.
+    // Requires that Morgue's config includes a custom asset alias and path
+    // that match a defined Alias directive in the Apache vhost config.
+    $config = Configuration::get_configuration();
+    if (isset($config['custom_assets']['alias']) and isset($config['custom_assets']['path'])) {
+        $custom_asset_alias = $config['custom_assets']['alias'];
+        $custom_asset_path = $config['custom_assets']['path'];
+        // Find dem scripts...
+        $custom_js = glob("$custom_asset_path/assets/js/*.js");
+        if ($custom_js) {
+            foreach ($custom_js as $js) {
+                // Replace the system path with the alias.
+                $aliased_js = str_replace($custom_asset_path, $custom_asset_alias, $js);
+                echo "<script type=\"text/javascript\" src=\"$aliased_js\"></script>";
+            }
+        }
+    }
+?>


### PR DESCRIPTION
- There may be cases where a developer would prefer not to release morgue features with the core project.
- This update allows the inclusion of morgue features from a distinct directory, to complement core features.
- It can even be used to override core features.
- To configure this support, the 'custom_features' and 'custom_feature_path' values need to be defined in the JSON config, as in 'example.json'.
- Finally, the web server needs to be configured with an appropriate alias to this location in case it's outside of morgue's document root.
- This has been tested with Apache using the following additional directives in a vhost configuration:

  ...
  Alias /morgue_custom_features /usr/local/morgue_features
  php_value include_path '.:/usr/share/pear:./features:/usr/local/morgue_features'
  ...