### PR TITLE
Remove stray newline at top of file

### DIFF
--- a/features/contact/lib.php
+++ b/features/contact/lib.php
@@ -1,4 +1,3 @@
-
 <?php
 
 class Contact {


### PR DESCRIPTION
The extra blank line before the ```<?php``` tag causes some minor problems as it gets sent as output before the ```<!DOCTYPE html>```.

At least in Google Chrome version 40.0.2214.115  this is resulting in : ```"Uncaught SyntaxError: Unexpected token <"```