### PR TITLE
fix displaying the summary in Firefox

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -201,7 +201,7 @@ function make_summary_editable(text) {
 
   // if not a textarea already, create one and replace the original div with it
   } else {
-    $.get(
+    $.getJSON(
       "/events/"+get_current_event_id()+"/summary",
       function(data) {
         var textarea = $("<textarea></textarea>")
@@ -330,14 +330,13 @@ function summary_edit_save_button() {
  * just abort editing and display the stored data as rendered HTML
  */
 function summary_cancel_button() {
-  $.get("/events/"+get_current_event_id()+"/summary", function(data) {
-    var summary = (JSON.parse(data)).summary;
+  $.getJSON("/events/"+get_current_event_id()+"/summary", function(data) {
     var html = $("<div></div>");
     html.attr("id", "summary");
     html.attr("name", "summary");
     html.attr("class", "input-xxlarge");
     html.attr("rows", "10");
-    html.html(markdown.toHTML(summary));
+    html.html(markdown.toHTML(data.summary));
     $("#summary").remove();
     $("#summarywrapper").append(html);
     $("#summaryeditbutton").html("Edit");

--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -13,9 +13,8 @@ $("#event-start-input-time").blur(update_starttime_for_event);
 $("#eventtitle").blur(update_title_for_event);
 $("#gcal").blur(update_gcal_for_event);
 $("#contact").blur(update_contact_for_event);
-$.get("/events/"+get_current_event_id()+"/summary", function(data) {
-    var summary = (JSON.parse(data)).summary;
-    $("#summary").html(markdown.toHTML(summary));
+$.getJSON("/events/"+get_current_event_id()+"/summary", function(data) {
+    $("#summary").html(markdown.toHTML(data.summary));
 });
 
 $('.datepicker')

--- a/assets/js/irc.js
+++ b/assets/js/irc.js
@@ -20,8 +20,7 @@ $('#ircchannels').on('click', 'span.close', function () {
 });
 
 function get_channel_data(url, params, channels, success_callback, error_callback) {
-  $.get(url, params, function(data) {
-    data = JSON.parse(data);
+  $.getJSON(url, params, function(data) {
     if (data.length === 0) {
       success_callback(channels);
     } else {


### PR DESCRIPTION
In FF, jQuery already parses the JSON for us when using get:

```
> $.get("/events/"+get_current_event_id()+"/summary", function(data) { console.log(data); })
Object { summary: "It was full of stars." }
```

In Chrome, it does not:

```
> $.get("/events/"+get_current_event_id()+"/summary", function(data) { console.log(data); })
{"summary":"It was full of stars."}
```

Therefore, parsing the "JSON" (actually, the string representation of
the already parsed object) fails and the summary does not display.

Use `getJSON` to let jQuery deal with this for us.

Note that I have tested editing in Firefox and Chrome on OS X with this, but I currently have nothing to test `irc.js` against.