### PR TITLE
Issue #62: add composer-merge-plugin to allow external features to speci...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,12 @@
 {
     "require": {
         "slim/slim": "1.6.*"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "../morgue_features/composer.json"
+                ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
-        "slim/slim": "1.6.*"
+        "slim/slim": "1.6.*",
+         "wikimedia/composer-merge-plugin": "dev-master"
     },
     "extra": {
         "merge-plugin": {


### PR DESCRIPTION
...fy deps

This seems to fail quietly and with grace (which is what we want) if the extra includes don't exist or can't be read.  It also brings in the deps specified in the external composer.json