### PR TITLE
Captured enter key for input fields

### DIFF
--- a/htdocs/assets/js/edit.js
+++ b/htdocs/assets/js/edit.js
@@ -46,4 +46,11 @@ $("#delete-no").click(function(ev) {
   ev.preventDefault();
   $('#delete-initial').show();
   $("#delete_button_confirmation_container").hide();
-})
+});
+
+// Enter key blurs input elements
+$(":input").keyup(function(e) {
+  if (e.keyCode == 13) {
+      e.target.blur();
+  }
+});


### PR DESCRIPTION
This prevents the enter key from submitting the entire edit page when focused on an input field and instead submits just the selected field.