### PR TITLE
No longer able to save morgue entry with blank title

### DIFF
--- a/htdocs/assets/js/api.js
+++ b/htdocs/assets/js/api.js
@@ -32,6 +32,11 @@ function show_save_status(event_type, success) {
 }
 
 function update_title_for_event() {
+  if (!$("#eventtitle").val()) {
+      show_save_status("Title", false);
+      return;
+  }
+
   var url = "/events/" + get_current_event_id();
   $.ajax({
         url: url,

--- a/views/content/edit.php
+++ b/views/content/edit.php
@@ -12,7 +12,7 @@
 <!-- Title -->
 <div class="row-fluid">
     <input class="input-headline" id="eventtitle" type="text"
-      value="<?php echo $event["title"] ?>">
+      value="<?php echo $event["title"] ?>" required>
 </div>
 
 <!-- Info Saved Notice -->


### PR DESCRIPTION
This fixes the bug that allowed saving an entry with a blank title, thus preventing it from being clicked on in the list of PMs.