### PR TITLE
Fixed bug preventing features from loading custom assets

### DIFF
--- a/features/anniversary/routes.php
+++ b/features/anniversary/routes.php
@@ -145,36 +145,3 @@ $app->get('/anniversary/mail', function () use ($app) {
 });
 
 
-// TODO: Can we add this to all feature routes? At least in the skeleton?
-// Handle custom static assets.
-// Javascript first then CSS.
-$app->get('/anniversary/js/:path' , function ($path) use ($app) {
-	// read the file if it exists. Then serve it back.	
-	$file = stream_resolve_include_path("anniversary/assets/js/{$path}");
-	if (!$file) {
-		$app->response->status(404);
-		$app->log->error("couldn't file custom js asset at $path");
-		return;
-	}
-    $thru_file = file_get_contents($file);
-	$app->response->header("Content-Type", "application/javascript");
-	print $thru_file;
-	return;
-});
-$app->get('/anniversary/css/:path' , function ($path) use ($app) {
-	// read the file if it exists. Then serve it back.	
-	$file = stream_resolve_include_path("anniversary/assets/css/{$path}");
-	if (!$file) {
-		$app->response->status(404);
-		$app->log->error("couldn't file custom css asset at $path");
-		return;
-	}	
-	$thru_file = file_get_contents($file);
-	$app->response->header("Content-Type", "text/css");
-    print $thru_file;
-    return;
-});
-
-
-
-

--- a/features/summary/assets/js/summary.js
+++ b/features/summary/assets/js/summary.js
@@ -48,6 +48,7 @@ function update_summary_for_event() {
  * save the markdown summary and render as HTML
  */
 function summary_edit_save_button() {
+    console.log("HERE");
     var button = $("#summaryeditbutton");
     var in_edit = (button.html() == "Save");
     if (in_edit) {

--- a/features/summary/assets/js/summary.js
+++ b/features/summary/assets/js/summary.js
@@ -1,0 +1,92 @@
+/**
+ * get the raw markdown summary and display it in a textedit area instead of
+ * the rendered HTML
+ * param: optional text to append to the textedit area
+ */
+function make_summary_editable(text) {
+    var $summary = $("#summary");
+
+    if (typeof text === "undefined") {
+        text = '';
+    } else {
+        text = "\n"+text;
+    }
+
+    // if a textarea already, append to it
+    if ($summary.is('textarea')) {
+        $summary.val(function(index, value){
+                return value + text;
+            });
+
+        // if not a textarea already, create one and replace the original div with it
+    } else {
+        $.getJSON(
+                  "/events/"+get_current_event_id()+"/summary",
+                  function(data) {
+                      var textarea = $("<textarea></textarea>")
+                          .attr({
+                                  "id": "summary",
+                                  "name": "summary",
+                                  "class": "input-xxlarge",
+                                  "rows": "10"
+                              })
+                          .val(data.summary + text);
+                      $summary.replaceWith(textarea);
+                  },
+                  'json' // forces return to be json decoded
+                  );
+    }
+}
+
+function update_summary_for_event() {
+    var url = "/events/" + get_current_event_id();
+    $.ajax({url: url, data: {summary: $("#summary").val()}, type: "PUT"});
+}
+
+/**
+ * Depending on the current state either show the editable summary form or
+ * save the markdown summary and render as HTML
+ */
+function summary_edit_save_button() {
+    var button = $("#summaryeditbutton");
+    var in_edit = (button.html() == "Save");
+    if (in_edit) {
+        update_summary_for_event();
+        var html = $("<div></div>");
+        html.attr("id", "summary");
+        html.attr("name", "summary");
+        html.attr("class", "input-xxlarge");
+        html.attr("rows", "10");
+        html.html(markdown.toHTML($("#summary").val()));
+        $("#summary").remove();
+        $("#summarywrapper").append(html);
+        button.html("Edit");
+        $("#summarycancelbutton").hide();
+
+    } else {
+        make_summary_editable();
+        button.html("Save");
+        $("#summarycancelbutton").show();
+    }
+}
+
+/**
+ * just abort editing and display the stored data as rendered HTML
+ */
+function summary_cancel_button() {
+    $.getJSON("/events/"+get_current_event_id()+"/summary", function(data) {
+            var html = $("<div></div>");
+            html.attr("id", "summary");
+            html.attr("name", "summary");
+            html.attr("class", "input-xxlarge");
+            html.attr("rows", "10");
+            html.html(markdown.toHTML(data.summary));
+            $("#summary").remove();
+            $("#summarywrapper").append(html);
+            $("#summaryeditbutton").html("Edit");
+            $("#summarycancelbutton").hide();
+        });
+}
+
+$("#summaryeditbutton").on("click", summary_edit_save_button);
+$("#summarycancelbutton").on("click", summary_cancel_button);

--- a/features/summary/assets/summmary.js~
+++ b/features/summary/assets/summmary.js~
@@ -1,2 +1,0 @@
-$("#summaryeditbutton").on("click", summary_edit_save_button);
-$("#summarycancelbutton").on("click", summary_cancel_button);

--- a/features/summary/assets/summmary.js~
+++ b/features/summary/assets/summmary.js~
@@ -1,0 +1,2 @@
+$("#summaryeditbutton").on("click", summary_edit_save_button);
+$("#summarycancelbutton").on("click", summary_cancel_button);

--- a/features/upload/routes.php
+++ b/features/upload/routes.php
@@ -3,36 +3,6 @@
  * Routes for upload
  */
 
-// Handle custom static assets.
-// Javascript first then CSS.
-$app->get('/upload/js/:path' , function ($path) use ($app) {
-	// read the file if it exists. Then serve it back.	
-	$file = stream_resolve_include_path("upload/assets/js/{$path}");
-	if (!$file) {
-		$app->response->status(404);
-		$app->log->error("couldn't file custom js asset at $path");
-		return;
-	}
-    $thru_file = file_get_contents($file);
-	$app->response->header("Content-Type", "application/javascript");
-	print $thru_file;
-	return;
-});
-$app->get('/upload/css/:path' , function ($path) use ($app) {
-	// read the file if it exists. Then serve it back.	
-	$file = stream_resolve_include_path("upload/assets/css/{$path}");
-	if (!$file) {
-		$app->response->status(404);
-		$app->log->error("couldn't file custom css asset at $path");
-		return;
-	}	
-	$thru_file = file_get_contents($file);
-	$app->response->header("Content-Type", "text/css");
-    print $thru_file;
-    return;
-});
-
-
 /*
  * This is to handle images coming in via our dropzone
  *

--- a/htdocs/assets/js/api.js
+++ b/htdocs/assets/js/api.js
@@ -184,46 +184,6 @@ function delete_forum_url_for_event(event_id, forum_url_id, callback) {
   $.ajax_delete(url, callback);
 }
 
-/**
- * get the raw markdown summary and display it in a textedit area instead of
- * the rendered HTML
- * param: optional text to append to the textedit area
- */
-function make_summary_editable(text) {
-  var $summary = $("#summary");
-
-  if (typeof text === "undefined") {
-    text = '';
-  } else {
-    text = "\n"+text;
-  }
-
-  // if a textarea already, append to it
-  if ($summary.is('textarea')) {
-    $summary.val(function(index, value){
-        return value + text;
-    });
-
-  // if not a textarea already, create one and replace the original div with it
-  } else {
-    $.getJSON(
-      "/events/"+get_current_event_id()+"/summary",
-      function(data) {
-        var textarea = $("<textarea></textarea>")
-          .attr({
-            "id": "summary",
-            "name": "summary",
-            "class": "input-xxlarge",
-            "rows": "10"
-          })
-          .val(data.summary + text);
-        $summary.replaceWith(textarea);
-      },
-      'json' // forces return to be json decoded
-    );
-  }
-}
-
 function update_gcal_for_event() {
   var url = "/events/" + get_current_event_id();
   var gcal = $("#gcal").val();
@@ -298,57 +258,6 @@ function update_contact_div(contact) {
   $("#the_contact").append(node);
   $("#contact").val('');
 }
-
-function update_summary_for_event() {
-  var url = "/events/" + get_current_event_id();
-  $.ajax({url: url, data: {summary: $("#summary").val()}, type: "PUT"});
-}
-
-/**
- * Depending on the current state either show the editable summary form or
- * save the markdown summary and render as HTML
- */
-function summary_edit_save_button() {
-  var button = $("#summaryeditbutton");
-  var in_edit = (button.html() == "Save");
-  if (in_edit) {
-    update_summary_for_event();
-    var html = $("<div></div>");
-    html.attr("id", "summary");
-    html.attr("name", "summary");
-    html.attr("class", "input-xxlarge");
-    html.attr("rows", "10");
-    html.html(markdown.toHTML($("#summary").val()));
-    $("#summary").remove();
-    $("#summarywrapper").append(html);
-    button.html("Edit");
-    $("#summarycancelbutton").hide();
-
-  } else {
-    make_summary_editable();
-    button.html("Save");
-    $("#summarycancelbutton").show();
-  }
-}
-
-/**
- * just abort editing and display the stored data as rendered HTML
- */
-function summary_cancel_button() {
-  $.getJSON("/events/"+get_current_event_id()+"/summary", function(data) {
-    var html = $("<div></div>");
-    html.attr("id", "summary");
-    html.attr("name", "summary");
-    html.attr("class", "input-xxlarge");
-    html.attr("rows", "10");
-    html.html(markdown.toHTML(data.summary));
-    $("#summary").remove();
-    $("#summarywrapper").append(html);
-    $("#summaryeditbutton").html("Edit");
-    $("#summarycancelbutton").hide();
-  });
-}
-
 
 function update_severity_for_event() {
   var url = "/events/" + get_current_event_id();

--- a/htdocs/assets/js/edit.js
+++ b/htdocs/assets/js/edit.js
@@ -1,5 +1,3 @@
-$("#summaryeditbutton").on("click", summary_edit_save_button);
-$("#summarycancelbutton").on("click", summary_cancel_button);
 $("#add-status").on("click", show_status_fields);
 $("#clear-status").on("click", remove_status_fields);
 $("#severity-select").change(update_severity_for_event);

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -438,8 +438,6 @@ $app->get('/ping', function () use ($app) {
 // Javascript first then CSS.
 $app->get('/features/:feature/js/:path' , function ($feature, $path) use ($app) {
         // read the file if it exists. Then serve it back.
-        var_dump($feature, $path);
-
         $file = stream_resolve_include_path("{$feature}/assets/js/{$path}");
         if (!$file) {
             $app->response->status(404);

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -434,5 +434,36 @@ $app->get('/ping', function () use ($app) {
 });
 
 
+// Handle custom static assets.
+// Javascript first then CSS.
+$app->get('/features/:feature/js/:path' , function ($feature, $path) use ($app) {
+        // read the file if it exists. Then serve it back.
+        var_dump($feature, $path);
+
+        $file = stream_resolve_include_path("{$feature}/assets/js/{$path}");
+        if (!$file) {
+            $app->response->status(404);
+            $app->log->error("couldn't file custom js asset at $path");
+            return;
+        }
+        $thru_file = file_get_contents($file);
+        $app->response->header("Content-Type", "application/javascript");
+        print $thru_file;
+        return;
+});
+
+$app->get('/features/:feature/css/:path' , function ($feature, $path) use ($app) {
+        // read the file if it exists. Then serve it back.
+        $file = stream_resolve_include_path("{$feature}/assets/css/{$path}");
+        if (!$file) {
+            $app->response->status(404);
+            $app->log->error("couldn't file custom css asset at $path");
+            return;
+        }
+        $thru_file = file_get_contents($file);
+        $app->response->header("Content-Type", "text/css");
+        print $thru_file;
+        return;
+});
 
 $app->run();

--- a/views/content/edit.php
+++ b/views/content/edit.php
@@ -226,7 +226,7 @@ Filler, to keep the same size
             }
 
             foreach ($css_assets as $css_file) {
-                echo "<link rel=\"stylesheet\" href=\"/{$feature_name}/css/{$css_file}\" />";
+                echo "<link rel=\"stylesheet\" href=\"/features/{$feature_name}/css/{$css_file}\" />";
             }
         }
 
@@ -244,7 +244,7 @@ Filler, to keep the same size
             }
 
             foreach ($js_assets as $js_file) {
-                echo "<script type=\"text/javascript\" src=\"/{$feature_name}/js/{$js_file}\"></script>";
+                echo "<script type=\"text/javascript\" src=\"/features/{$feature_name}/js/{$js_file}\"></script>";
             }
         }
     }

--- a/views/header.php
+++ b/views/header.php
@@ -19,7 +19,7 @@
 					$js_assets = $navbar_feature['custom_js_assets'];
 				}
 				foreach ($js_assets as $js_asset) {
-					?><script type="text/javascript" src="/<?php echo $navbar_feature['name'] ?>/js/<?php echo $js_asset ?>"></script><?php 
+					?><script type="text/javascript" src="/features/<?php echo $navbar_feature['name'] ?>/js/<?php echo $js_asset ?>"></script><?php 
 				}
 			}
 ?></li>


### PR DESCRIPTION
Currently, features are unable to load custom assets unless they create a routing to it in their corresponding routes.php file. This should be done automatically by simply enabling custom assets in the config.json file. I also moved the javascript code powering the summary feature into it's assets folder. The reason for this is that disabling the summary feature would leave dead code in the api.js file and it also makes it harder to extend the summary feature in the future. 