### PR TITLE
Log error if HTTP repsponse is not 200 OK

### DIFF
--- a/phplib/CurlClient.php
+++ b/phplib/CurlClient.php
@@ -17,6 +17,10 @@ class CurlClient {
         }
         curl_setopt_array($ch, $options);
         $result = trim(curl_exec($ch));
+        $status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($status_code != 200) {
+            error_log("Got unexpected HTTP status code $status_code from $url");
+        }
         curl_close($ch);
         return $result;
     }


### PR DESCRIPTION
When sending user and password to jira.atlassian.com it returns HTTP 401 Unauthorized. It works w/o username/password. But it would be nice to have error reporting so the issue becomes obvious. The same is true for wrong username/password situations.