### PR TITLE
Use utf8mb4 to connect to the database.

### DIFF
--- a/phplib/Persistence.php
+++ b/phplib/Persistence.php
@@ -440,7 +440,7 @@ class Persistence {
         $user = $config['database']['username'];
         $pass = $config['database']['password'];
         try {
-            $conn = new PDO('mysql:host='.$host.';port='.$port.';dbname='.$adb, $user, $pass);
+            $conn = new PDO('mysql:host='.$host.';port='.$port.';dbname='.$adb.';charset=utf8mb4', $user, $pass);
             $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
             return $conn;
         } catch(PDOException $e) {


### PR DESCRIPTION
if you use a mysql client and do "SET NAMES utf8mb4;" the pm and
tag names should be correct now. Test this by creating a pm and or
tag with unicode characters like ë, æ, ç or 😉

This will *NOT* correct previously created data. Convert this data
before switching or you will get mojibake.