### PR TITLE
Prevent negative resolve time when detect > end time.

### DIFF
--- a/htdocs/assets/js/api.js
+++ b/htdocs/assets/js/api.js
@@ -327,17 +327,25 @@ function update_undetected_time() {
   $('#undetecttime').val(getTimeString(enddate - startdate));
 }
 function update_resolve_time() {
-  var startdate = new Date($("input#event-detect-input-date").val());
-  var starttime = timeToDate($("input#event-detect-input-time").val());
+  var startdate = new Date($("input#event-start-input-date").val());
+  var starttime = timeToDate($("input#event-start-input-time").val());
+  var detectdate = new Date($("input#event-detect-input-date").val());
+  var detecttime = timeToDate($("input#event-detect-input-time").val());
   var enddate = new Date($("input#event-end-input-date").val());
   var endtime = timeToDate($("input#event-end-input-time").val());
 
   startdate.setHours(starttime.getHours());
   startdate.setMinutes(starttime.getMinutes());
+  detectdate.setHours(detecttime.getHours());
+  detectdate.setMinutes(detecttime.getMinutes());
   enddate.setHours(endtime.getHours());
   enddate.setMinutes(endtime.getMinutes());
 
-  $('#resolvetime').val(getTimeString(enddate - startdate));
+  if (enddate >= detectdate) {
+    $('#resolvetime').val(getTimeString(enddate - detectdate));
+  } else {
+    $('#resolvetime').val(getTimeString(enddate - startdate));
+  }
 }
 
 function update_history(history) {

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -238,7 +238,11 @@ $app->get('/events/:id', function($id) use ($app) {
     $detect_datetime = new DateTime("@$detect_time");
     $detect_datetime->setTimezone($tz);
     $impacttime = getTimeString($endtime - $starttime);
-    $resolvetime = getTimeString($endtime - $detect_time);
+    if ($endtime >= $detect_time) {
+        $resolvetime = getTimeString($endtime - $detect_time);
+    } else {
+        $resolvetime = $impacttime;
+    }
     $undetecttime = getTimeString($detect_time - $starttime);
 
     $edit_status = Postmortem::get_event_edit_status($event);


### PR DESCRIPTION
Occasionally events will resolve before they are detected. Currently
this results in a negative resolve time. This patch makes it so resolve
time == impact time in this particular case.
