### PR TITLE
add support for timeout to CurlClient

### DIFF
--- a/phplib/CurlClient.php
+++ b/phplib/CurlClient.php
@@ -2,7 +2,8 @@
 
 class CurlClient {
 
-    function get($url, array $params = null, $user_pass = null, $proxy = null) {
+    function get($url, array $params = null, $user_pass = null, $proxy = null,
+                 $timeout = 10) {
         $query_string = empty($params)
             ? ''
             : '?' . http_build_query($params);
@@ -10,7 +11,8 @@ class CurlClient {
         $options = array(
             CURLOPT_HTTPGET => true,
             CURLOPT_FOLLOWLOCATION => 1,
-            CURLOPT_RETURNTRANSFER => 1
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_TIMEOUT => $timeout,
         );
         if ($user_pass) {
             if ($user_pass != ":") {

--- a/tests/unit/CurlClient_Test.php
+++ b/tests/unit/CurlClient_Test.php
@@ -1,0 +1,25 @@
+
+<?php
+
+require_once("phplib/CurlClient.php");
+
+class CurlClientTest extends PHPUnit_Framework_TestCase {
+
+    public function setUp() {
+        $this->curl_client = new CurlClient();
+    }
+
+    public function test_get() {
+
+        $res = $this->curl_client->get("http://httpbin.org/get");
+        $res = json_decode($res, true);
+        $this->assertEquals("http://httpbin.org/get", $res["url"]);
+    }
+
+    public function test_getWithTimeout() {
+        $res = $this->curl_client->get("http://httpbin.org/delay/3", null, null, null, 1);
+        $res = json_decode($res);
+        $this->assertNull($res);
+    }
+
+}


### PR DESCRIPTION
this allows for setting a timeout to the CurlClient implementation so it fails
faster when external services are not available. The default is set to 10
seconds which is pretty conservative but not too long. Features using the
CurlClient should pass their own to match their needs.