### PR TITLE
Ignore phplib/deploy_version.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config/development.json
 *.swp
 composer.lock
 composer.phar
+phplib/deploy_version.php

--- a/phplib/deploy_version.php
+++ b/phplib/deploy_version.php
@@ -1,3 +1,0 @@
-<?php
-
-define('MORGUE_VERSION', '9225b95');


### PR DESCRIPTION
This file was added during the Slim 1.x - > 2.x migration.  This commit nukes the file and adds the file to be ignored by git.