### PR TITLE
adds php mysql driver as setup requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can also join `#morgue` on Freenode IRC if you have questions.
 ### Requirements
 - PHP 5.3 or higher
 - MySQL 5.5 or higher
+- PHP MySQL driver
 - Apache
 - mod_rewrite
 


### PR DESCRIPTION
Relates to issue #51 

When the php mysql driver is not present, this is the resulting error message "Couldn't get connection object." It is not very indicative of a missing driver.

Fortunately, issue #51 deals with this problem and proposes a working solution. I also came across this problem and struggled with it for a while before I came across the solution. This PR is meant to clarify the need for the php mysql driver and to make life easier for the next person wishing to configure morgue on a server. 