### PR TITLE
Jira ticket feature

### DIFF
--- a/features/jira/lib.php
+++ b/features/jira/lib.php
@@ -303,5 +303,36 @@ class JiraClient {
 
         return $ticket;
     }
+
+    /**
+     * Given project, summary, description and issuetype, this
+     * function creates a jira ticket using that information.
+     *
+     * @param $project -> project name
+     * @param $summary -> summary of the ticket to be created
+     * @param $description -> description of the ticket to be created
+     * @param $issuetype -> the type of issue
+     *
+     * @return $jira_api_response, an array of json-decoded issues as returned by JIRA
+     */
+
+    public function createJiraTicket($project, $summary, $description, $issuetype) {
+        $params = array(
+            'fields' => array(
+                'project' => array(
+                    'key' => $project
+                ),
+                'summary' => $summary,
+                'description' => $description,
+                'issuetype' => array(
+                    'name' => $issuetype
+                )
+            )
+        );
+        $response = $this->curl_client->post($this->getJiraBaseUrl(). '/rest/api/2/issue', $params, $this->username . ':' . $this->password, $this->proxy);
+        $jira_api_response = json_decode($response, true);
+
+        return $jira_api_response;
+    }
 }
 ?>

--- a/features/jira/routes.php
+++ b/features/jira/routes.php
@@ -12,6 +12,29 @@ $app->get('/events/:id/tickets', function($id) use ($app) {
     }
 
 });
+
+$app->post('/events/:id/tickets/create', function ($id) use ($app) {
+    header("Content-Type: application/json");
+    $curl = new CurlClient();
+    $jira = new JiraClient($curl);
+    $project = $app->request()->post('project');
+    $summary = $app->request()->post('summary');
+    $description = $app->request()->post('description');
+    $issuetype = $app->request()->post('issuetype');
+    $res = $jira->createJiraTicket($project, $summary, $description, $issuetype);
+    if ($res["status"] == Jira::ERROR) {
+        $app->response->status(400);
+    } else {
+        $app->response->status(201);
+        if ($tickets["status"] == Jira::ERROR) {
+            $app->response->status(404);
+            return;
+        } else {
+            echo json_encode($res);
+        }
+    }
+
+});
 $app->post('/events/:id/tickets', function($id) use ($app) {
     header("Content-Type: application/json");
     $curl = new CurlClient();

--- a/features/jira/views/jira.php
+++ b/features/jira/views/jira.php
@@ -14,7 +14,11 @@
 <legend>Remediation</legend> 
   
   <div class="editable_hidden" style="display:none;">
-  <div id="jira-link"><a href="<?php echo $jira_client->getJiraBaseUrl(); ?>/secure/CreateIssue!default.jspa" target="_new">Create New Issue</a></div>
+  <input type="text" id="jira_project_name" name="jira_project_name" class="input-xxlarge" placeholder="Project Name">
+  <input type="text" id="jira_summary" name="jira_summary" class="input-xxlarge" placeholder="Summary">
+  <input type="text" id="jira_description" name="jira_description" class="input-xxlarge" placeholder="Description">
+  <input type="text" id="jira_issuetype" name="jira_issuetype" class="input-xxlarge" placeholder="Issue Type">
+  <button onclick="createTicket()"> Create Ticket </button>
   <input type="text" placeholder="Enter JIRA key(s), separated by commas (i.e. CORE-2024, OPS-1453)" id="jira_key_input" name="jira_key_input" class="input-xxlarge" onblur="addTicket()">
   </div>
 

--- a/htdocs/assets/js/api.js
+++ b/htdocs/assets/js/api.js
@@ -68,6 +68,22 @@ function store_ticket_for_event(id, ticket, callback) {
   $.post(url, data, callback);
 }
 /**
+ * function to create a ticket.
+ * @param id - event ID
+ * @param project - name of the project that the ticket will belong to
+ * @param summary - summary of the ticket
+ * @param description - description of the ticket
+ * @param issuetype - the type of the ticket that will be created
+ * @param callback - callback function
+ */
+function create_ticket_for_event(id, project, summary, description, issuetype, callback) {
+  console.log("creating ticket!");
+  var url = "/events/" + id + "/tickets/create";
+  var data = {"project": project, "summary": summary, "description": description, "issuetype": issuetype};
+  $.post(url, data, callback);
+}
+
+/**
  * function to store an IRC channel for an event via the REST API
  *
  * @param id - event ID

--- a/htdocs/assets/js/jira.js
+++ b/htdocs/assets/js/jira.js
@@ -1,3 +1,44 @@
+function createTicket() {
+    var jira_project_name = $("#jira_project_name").attr("value");
+    var jira_summary = $("#jira_summary").attr("value");
+    var jira_description = $("#jira_description").attr("value");
+    var jira_issuetype = $("#jira_issuetype").attr("value");
+
+    var jira_pn = $("jira_project_name");
+    create_ticket_for_event(get_current_event_id(), jira_project_name,
+                            jira_summary, jira_description, jira_issuetype,
+                            function(data) {
+                                data = JSON.parse(data);
+                                var ticket_num = data["key"];
+                                store_ticket_for_event(get_current_event_id(), ticket_num, function(data) {
+                                    data = JSON.parse(data);
+                                    var keys = $.map(ticket_num.split(","), function(n,i){return ($.trim(n)).toUpperCase();});
+                                    for (var i in data) {
+                                        // add entries
+                                        if ($.inArray(i, keys) !== -1) {
+                                            var style = "jira_" +  data[i].status.toLowerCase().replace(" ", "_");
+
+                                            var entry = "<tr class=\"jira-row\">";
+                                            entry += "<td><a href=\""+data[i].ticket_url+"\" class=\""+ style + "\">"+i+"</a></td>";
+                                            entry += "<td>"+data[i].summary+"</td>";
+                                            entry += "<td>"+data[i].assignee+"</td>";
+                                            $('th.jira_addition_field').each(function(index, value){
+                                                field = $(value).text();
+                                                entry += "<td>"+(data[i][field] || "" )+"</td>";
+                                            });
+                                            entry += "<td><span id=\"jira-"+data[i].id+"\" class='close'>&times;</span></td>";
+                                            entry += "</tr>";
+
+                                            $('#jira_table_body').append(entry);
+                                            addTooltip($("tr[class=jira-row] a[class="+style+"]"));
+                                        }
+                                    }
+                                });
+
+                            }
+                           )
+}
+
 function addTicket() {
     var jira_input = $("#jira_key_input");
     var jira_keys = (jira_input.attr("value"));
@@ -6,11 +47,11 @@ function addTicket() {
             data = JSON.parse(data);
             var keys = $.map(jira_keys.split(","), function(n,i){return ($.trim(n)).toUpperCase();});
             for (var i in data) {
-              // add entries
-              if ($.inArray(i, keys) !== -1) {
-                var style = "jira_" +  data[i].status.toLowerCase().replace(" ", "_");
+                // add entries
+                if ($.inArray(i, keys) !== -1) {
+                    var style = "jira_" +  data[i].status.toLowerCase().replace(" ", "_");
 
-                var entry = "<tr class=\"jira-row\">";
+                    var entry = "<tr class=\"jira-row\">";
                     entry += "<td><a href=\""+data[i].ticket_url+"\" class=\""+ style + "\">"+i+"</a></td>";
                     entry += "<td>"+data[i].summary+"</td>";
                     entry += "<td>"+data[i].assignee+"</td>";
@@ -20,10 +61,10 @@ function addTicket() {
                     });
                     entry += "<td><span id=\"jira-"+data[i].id+"\" class='close'>&times;</span></td>";
                     entry += "</tr>";
-                
-                $('#jira_table_body').append(entry);
-                addTooltip($("tr[class=jira-row] a[class="+style+"]"));
-              }
+
+                    $('#jira_table_body').append(entry);
+                    addTooltip($("tr[class=jira-row] a[class="+style+"]"));
+                }
             }
             jira_input.attr("value", "");
         });
@@ -61,4 +102,3 @@ function addTooltip(entry) {
 $("tr[class=jira-row] a[class^=jira_]").each(function () {
     addTooltip($(this));
 });
-

--- a/phplib/CurlClient.php
+++ b/phplib/CurlClient.php
@@ -5,8 +5,8 @@ class CurlClient {
     function get($url, array $params = null, $user_pass = null, $proxy = null,
                  $timeout = 10) {
         $query_string = empty($params)
-            ? ''
-            : '?' . http_build_query($params);
+                      ? ''
+                      : '?' . http_build_query($params);
         $ch = curl_init($url . $query_string);
         $options = array(
             CURLOPT_HTTPGET => true,
@@ -29,6 +29,39 @@ class CurlClient {
             error_log("Got unexpected HTTP status code $status_code from $url");
         }
         curl_close($ch);
+        return $result;
+    }
+
+    function post($url, array $params = null, $user_pass = null, $proxy = null, $timeout = 10) {
+        //open connection
+        $query_string = empty($params)
+                      ? ''
+                      : '?' . http_build_query($params);
+        $ch = curl_init($url . $query_string);
+
+        //set the url, number of POST vars, POST data
+        curl_setopt($ch,CURLOPT_URL, $url);
+
+        curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($ch, CURLOPT_VERBOSE, true);
+        curl_setopt($ch,CURLOPT_POST, 1);
+        curl_setopt($ch,CURLOPT_HEADER, 0);
+        curl_setopt($ch,CURLOPT_HTTPHEADER, array('Content-Type: application/json;charset=UTF-8'));
+        curl_setopt($ch,CURLOPT_TIMEOUT, $timeout);
+        curl_setopt($ch,CURLOPT_POSTFIELDS, json_encode($params));
+        curl_setopt($ch,CURLOPT_USERPWD, $user_pass);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        //execute post
+        $result = curl_exec($ch);
+        $status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($status_code != 200) {
+            error_log("Got unexpected HTTP status code $status_code from $url");
+        }
+        //close connection
+        curl_close($ch);
+
         return $result;
     }
 }


### PR DESCRIPTION
Instead of providing a link to Jira to create tickets, this feature allows users to create Jira tickets right from Morgue. It also handles the issue of linking the newly made ticket to the post-mortem that is being edited.

Note: You can still add tickets by their ticket ID. That feature is still present.
