### PR TITLE
event confirmation dialog, pin phpunit with composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ install:
   - composer self-update
   - composer install --dev
 php:
-  - "5.3"
-  - "5.4"
-  - "5.5"
+  - "7.0"
+  - "7.1"
 script: make unittests
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # make it so
 #
 
-PHPUNIT:=phpunit --include-path=phplib --log-junit results.xml
+PHPUNIT:=vendor/bin/phpunit --include-path=phplib --log-junit results.xml
 VERSION := $(shell git rev-parse --short HEAD)
 
 # targets

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can also join `#morgue` on Freenode IRC if you have questions.
 ## Setup
 
 ### Requirements
-- PHP 5.3 or higher
+- PHP 7.0 or higher
 - MySQL 5.5 or higher
 - PHP MySQL driver
 - Apache

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
                 "features/upload/composer.json"
                 ]
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6"
     }
 }

--- a/features/calendar/assets/js/calendar.js
+++ b/features/calendar/assets/js/calendar.js
@@ -233,6 +233,13 @@ function checkEventExists()
 function createEvent()
 {
     var event = generateEvent();
+
+    var is_confirmed = confirm("About to create an event and invite all postmortem email subscribers. Proceed?");
+
+    if (!is_confirmed) {
+	return;
+    }
+
     var params = {
         'calendarId' : cal.id,
         'resource' : event,

--- a/tests/unit/Contact_Test.php
+++ b/tests/unit/Contact_Test.php
@@ -2,7 +2,7 @@
 
 require_once("features/contact/lib.php");
 
-class ContactTest extends PHPUnit_Framework_TestCase {
+class ContactTest extends \PHPUnit\Framework\TestCase {
 
     public function test_getUrlForUser_lookupDefined() {
         $config = array('lookup_url' => 'http://foo/%s/bar');

--- a/tests/unit/CurlClient_Test.php
+++ b/tests/unit/CurlClient_Test.php
@@ -3,7 +3,7 @@
 
 require_once("phplib/CurlClient.php");
 
-class CurlClientTest extends PHPUnit_Framework_TestCase {
+class CurlClientTest extends \PHPUnit\Framework\TestCase {
 
     public function setUp() {
         $this->curl_client = new CurlClient();

--- a/tests/unit/JiraClient_Test.php
+++ b/tests/unit/JiraClient_Test.php
@@ -4,7 +4,7 @@ require_once("features/jira/lib.php");
 require_once("phplib/CurlClient.php");
 require_once("phplib/Configuration.php");
 
-class JiraClientTest extends PHPUnit_Framework_TestCase {
+class JiraClientTest extends \PHPUnit\Framework\TestCase {
     const JIRA_BASE_URL = "https://jira.foo.com";
     const JIRA_USERNAME = 'jira';
     const JIRA_PASSWORD = 'credentials';
@@ -12,7 +12,7 @@ class JiraClientTest extends PHPUnit_Framework_TestCase {
 
     public function setUp() {
         // create a mock curl client
-        $this->curl_client = $this->getMock('CurlClient', array('get'));
+        $this->curl_client = $this->createMock('CurlClient', array('get'));
         $this->jira_client = new JiraClient(
             $this->curl_client, array(
                 "baseurl" => self::JIRA_BASE_URL,


### PR DESCRIPTION
This adds a confirmation dialog before creating an event, warning that emails will be sent to all subscribers. With the current behavior it is easy to accidentally invite large mailing lists. 

In order to run unit tests, I pinned to a recent version of `phpunit` with composer. It required the following changes to test files:
- use namespaced `\PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`
- remove use of deprecated `getMock` method