### PR TITLE
Handling Undefined index and facilitator

### DIFF
--- a/features/calendar/lib.php
+++ b/features/calendar/lib.php
@@ -9,9 +9,9 @@ class Calendar extends Persistence{
         $this->apiKey = $config['apiKey'];
         $this->scopes = $config['scopes'];
         $this->id = $config['id'];
-        $this->override_calendar_link = $config['override_calendar_link'];
-        $this->override_calendar_link_href = $config['override_calendar_link_href'];
-        $this->override_calendar_link_description = $config['override_calendar_link_description'];
+        $this->override_calendar_link = array_key_exists('override_calendar_link', $config) ? $config['override_calendar_link']: '';
+        $this->override_calendar_link_href = array_key_exists('override_calendar_link_href', $config) ? $config['override_calendar_link_href']: '';
+        $this->override_calendar_link_description = array_key_exists('override_calendar_link_description', $config) ? $config['override_calendar_link_description'] : '';
         $this->facilitator = $config['facilitator'];
         if (isset($config['attendees_email'])) {
             if (!is_array($config['attendees_email'])) {

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -200,6 +200,7 @@ $app->post('/events', function () use ($app) {
         "why_surprised" => "",
         "tldr" => "",
         "meeting_notes_link" => "",
+        "facilitator" => "",
         "starttime" => $startdate->getTimeStamp(),
         "endtime" => $enddate->getTimeStamp(),
         "statustime" => $statusdate->getTimeStamp(),
@@ -213,6 +214,9 @@ $app->post('/events', function () use ($app) {
     );
 
     $event = Postmortem::save_event($event);
+    if(isset($event['error'])) {
+        error_log(print_r($event,true));
+    }
     $app->redirect('/events/'.$event["id"]);
 });
 


### PR DESCRIPTION
Use calendar config only if it set so that undefined index can be avoided.
And pass facilitator as empty incase of add so that morgue entry creation doesn't affect and log error incase of it is set.